### PR TITLE
Introducing a new parameter: scalable button symbols (butsymbolscale)

### DIFF
--- a/AnimCube2.js
+++ b/AnimCube2.js
@@ -558,7 +558,7 @@ function AnimCube2(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5) {param = 0.5}
+      if (param < 0.5 || param > 2.5) {param = 1.0}
       if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
       buttonSymbolScale = param;
     }

--- a/AnimCube2.js
+++ b/AnimCube2.js
@@ -558,9 +558,11 @@ function AnimCube2(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5 || param > 2.5) {param = 1.0}
-      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
-      buttonSymbolScale = param;
+      if (n > 0) {
+        if (n < 0.5 || n > 2.5) {n = 1.0}
+        if (n > 1+(buttonHeight-9)*0.09375) {n = 1+(buttonHeight-9)*0.09375}
+        buttonSymbolScale = n;
+      }
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;

--- a/AnimCube2.js
+++ b/AnimCube2.js
@@ -1940,13 +1940,13 @@ function AnimCube2(params) {
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1*buttonSymbolScale);
         break;
     }
   }

--- a/AnimCube2.js
+++ b/AnimCube2.js
@@ -130,6 +130,8 @@ function AnimCube2(params) {
   var buttonBar; // button bar mode
   var buttonHeight;
   var drawButtons = true;
+  // introducing buttonSymbolScale
+  var buttonSymbolScale = 1.0;
   var pushed;
   var buttonPressed = -1;
   var progressHeight = 6;
@@ -551,6 +553,14 @@ function AnimCube2(params) {
       var n = parseInt(param);
       if (n >= 9 & n <= 25)
         buttonHeight = n;
+    }
+    // get button symbols' scale, default = 1, 0.5 min., 2.5 max. according to buttonHeight
+    param = getParameter("butsymbolscale");
+    if (param != null) {
+      var n = parseFloat(param);
+      if (param < 0.5) {param = 0.5}
+      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
+      buttonSymbolScale = param;
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;
@@ -1899,50 +1909,50 @@ function AnimCube2(params) {
     y = Math.floor(y);
     switch (i) {
       case 0: // rewind
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x + ds[4], y, -1); // left
+        drawRect(g, x - ds[4]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[4]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 1: // reverse step
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[1], y, -1); // left
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 2: // reverse play
-        drawArrow(g, x + ds[1], y, -1); // left
+        drawArrow(g, x + ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 3: // stop / mirror
         if (animating)
-          drawRect(g, x - ds[4], y - ds[3], ds[7], ds[7]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[3]+ds[4])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[7]*buttonSymbolScale);
         else {
-          drawRect(g, x - ds[4], y - ds[2], ds[7], ds[5]);
-          drawRect(g, x - ds[2], y - ds[4], ds[3], ds[9]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[2]+ds[3])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[5]*buttonSymbolScale);
+          drawRect(g, x - ds[2]*buttonSymbolScale, y - (ds[4]+ds[5])/2*buttonSymbolScale, ds[3]*buttonSymbolScale, ds[9]*buttonSymbolScale);
         }
         break;
       case 4: // play
-        drawArrow(g, x - ds[2], y, 1); // right
+        drawArrow(g, x - ds[2]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 5: // step
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x, y, 1); // right
+        drawRect(g, x - (ds[4]+ds[5])/2*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[1]/2*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 6: // fast forward
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[4], y, 1); // right
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[4]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x+dpr*2 + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x-dpr + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
         break;
     }
   }
 
   function drawArrow(g, x, y, dir) {
-    var d3 = 3 * dpr;
+    var d3 = (3 * dpr)*buttonSymbolScale;
     var fillX = [];
     var fillY = [];
     fillX[0] = x;

--- a/AnimCube3.js
+++ b/AnimCube3.js
@@ -2023,13 +2023,13 @@ function AnimCube3(params) {
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1*buttonSymbolScale);
         break;
     }
   }

--- a/AnimCube3.js
+++ b/AnimCube3.js
@@ -567,7 +567,7 @@ function AnimCube3(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5) {param = 0.5}
+      if (param < 0.5 || param > 2.5) {param = 1.0}
       if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
       buttonSymbolScale = param;
     }

--- a/AnimCube3.js
+++ b/AnimCube3.js
@@ -567,9 +567,11 @@ function AnimCube3(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5 || param > 2.5) {param = 1.0}
-      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
-      buttonSymbolScale = param;
+      if (n > 0) {
+        if (n < 0.5 || n > 2.5) {n = 1.0}
+        if (n > 1+(buttonHeight-9)*0.09375) {n = 1+(buttonHeight-9)*0.09375}
+        buttonSymbolScale = n;
+      }
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;

--- a/AnimCube3.js
+++ b/AnimCube3.js
@@ -130,6 +130,8 @@ function AnimCube3(params) {
   var buttonBar; // button bar mode
   var buttonHeight;
   var drawButtons = true;
+  // including buttonSymbolScale
+  var buttonSymbolScale = 1.0;
   var pushed;
   var buttonPressed = -1;
   var progressHeight = 6;
@@ -560,6 +562,14 @@ function AnimCube3(params) {
       var n = parseInt(param);
       if (n >= 9 & n <= 25)
         buttonHeight = n;
+    }
+    // get button symbols' scale, default = 1, 0.5 min., 2.5 max. according to buttonHeight
+    param = getParameter("butsymbolscale");
+    if (param != null) {
+      var n = parseFloat(param);
+      if (param < 0.5) {param = 0.5}
+      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
+      buttonSymbolScale = param;
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;
@@ -1982,50 +1992,50 @@ function AnimCube3(params) {
     y = Math.floor(y);
     switch (i) {
       case 0: // rewind
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x + ds[4], y, -1); // left
+        drawRect(g, x - ds[4]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[4]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 1: // reverse step
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[1], y, -1); // left
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 2: // reverse play
-        drawArrow(g, x + ds[1], y, -1); // left
+        drawArrow(g, x + ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 3: // stop / mirror
         if (animating)
-          drawRect(g, x - ds[4], y - ds[3], ds[7], ds[7]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[3]+ds[4])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[7]*buttonSymbolScale);
         else {
-          drawRect(g, x - ds[4], y - ds[2], ds[7], ds[5]);
-          drawRect(g, x - ds[2], y - ds[4], ds[3], ds[9]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[2]+ds[3])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[5]*buttonSymbolScale);
+          drawRect(g, x - ds[2]*buttonSymbolScale, y - (ds[4]+ds[5])/2*buttonSymbolScale, ds[3]*buttonSymbolScale, ds[9]*buttonSymbolScale);
         }
         break;
       case 4: // play
-        drawArrow(g, x - ds[2], y, 1); // right
+        drawArrow(g, x - ds[2]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 5: // step
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x, y, 1); // right
+        drawRect(g, x - (ds[4]+ds[5])/2*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[1]/2*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 6: // fast forward
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[4], y, 1); // right
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[4]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x+dpr*2 + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x-dpr + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
         break;
     }
   }
 
   function drawArrow(g, x, y, dir) {
-    var d3 = 3 * dpr;
+    var d3 = (3 * dpr)*buttonSymbolScale;
     var fillX = [];
     var fillY = [];
     fillX[0] = x;

--- a/AnimCube4.js
+++ b/AnimCube4.js
@@ -564,9 +564,11 @@ function AnimCube4(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5 || param > 2.5) {param = 1.0}
-      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
-      buttonSymbolScale = param;
+      if (n > 0) {
+        if (n < 0.5 || n > 2.5) {n = 1.0}
+        if (n > 1+(buttonHeight-9)*0.09375) {n = 1+(buttonHeight-9)*0.09375}
+        buttonSymbolScale = n;
+      }
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;

--- a/AnimCube4.js
+++ b/AnimCube4.js
@@ -130,6 +130,8 @@ function AnimCube4(params) {
   var buttonBar; // button bar mode
   var buttonHeight;
   var drawButtons = true;
+  // including buttonSymbolScale
+  var buttonSymbolScale = 1.0;
   var pushed;
   var buttonPressed = -1;
   var progressHeight = 6;
@@ -557,6 +559,14 @@ function AnimCube4(params) {
       var n = parseInt(param);
       if (n >= 9 & n <= 25)
         buttonHeight = n;
+    }
+    // get button symbols' scale, default = 1, 0.5 min., 2.5 max. according to buttonHeight
+    param = getParameter("butsymbolscale");
+    if (param != null) {
+      var n = parseFloat(param);
+      if (param < 0.5) {param = 0.5}
+      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
+      buttonSymbolScale = param;
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;
@@ -2112,50 +2122,50 @@ function AnimCube4(params) {
     y = Math.floor(y);
     switch (i) {
       case 0: // rewind
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x + ds[4], y, -1); // left
+        drawRect(g, x - ds[4]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[4]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 1: // reverse step
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[1], y, -1); // left
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 2: // reverse play
-        drawArrow(g, x + ds[1], y, -1); // left
+        drawArrow(g, x + ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 3: // stop / mirror
         if (animating)
-          drawRect(g, x - ds[4], y - ds[3], ds[7], ds[7]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[3]+ds[4])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[7]*buttonSymbolScale);
         else {
-          drawRect(g, x - ds[4], y - ds[2], ds[7], ds[5]);
-          drawRect(g, x - ds[2], y - ds[4], ds[3], ds[9]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[2]+ds[3])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[5]*buttonSymbolScale);
+          drawRect(g, x - ds[2]*buttonSymbolScale, y - (ds[4]+ds[5])/2*buttonSymbolScale, ds[3]*buttonSymbolScale, ds[9]*buttonSymbolScale);
         }
         break;
       case 4: // play
-        drawArrow(g, x - ds[2], y, 1); // right
+        drawArrow(g, x - ds[2]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 5: // step
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x, y, 1); // right
+        drawRect(g, x - (ds[4]+ds[5])/2*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[1]/2*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 6: // fast forward
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[4], y, 1); // right
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[4]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x+dpr*2 + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x-dpr + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
         break;
     }
   }
 
   function drawArrow(g, x, y, dir) {
-    var d3 = 3 * dpr;
+    var d3 = (3 * dpr)*buttonSymbolScale;
     var fillX = [];
     var fillY = [];
     fillX[0] = x;

--- a/AnimCube4.js
+++ b/AnimCube4.js
@@ -564,7 +564,7 @@ function AnimCube4(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5) {param = 0.5}
+      if (param < 0.5 || param > 2.5) {param = 1.0}
       if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
       buttonSymbolScale = param;
     }

--- a/AnimCube4.js
+++ b/AnimCube4.js
@@ -2153,13 +2153,13 @@ function AnimCube4(params) {
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1*buttonSymbolScale);
         break;
     }
   }

--- a/AnimCube5.js
+++ b/AnimCube5.js
@@ -2194,13 +2194,13 @@ function AnimCube5(params) {
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1*buttonSymbolScale);
         break;
     }
   }

--- a/AnimCube5.js
+++ b/AnimCube5.js
@@ -557,9 +557,11 @@ function AnimCube5(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5 || param > 2.5) {param = 1.0}
-      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
-      buttonSymbolScale = param;
+      if (n > 0) {
+        if (n < 0.5 || n > 2.5) {n = 1.0}
+        if (n > 1+(buttonHeight-9)*0.09375) {n = 1+(buttonHeight-9)*0.09375}
+        buttonSymbolScale = n;
+      }
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;

--- a/AnimCube5.js
+++ b/AnimCube5.js
@@ -557,7 +557,7 @@ function AnimCube5(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5) {param = 0.5}
+      if (param < 0.5 || param > 2.5) {param = 1.0}
       if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
       buttonSymbolScale = param;
     }

--- a/AnimCube5.js
+++ b/AnimCube5.js
@@ -130,6 +130,8 @@ function AnimCube5(params) {
   var buttonBar; // button bar mode
   var buttonHeight;
   var drawButtons = true;
+  // including buttonSymbolScale
+  var buttonSymbolScale = 1.0;
   var pushed;
   var buttonPressed = -1;
   var progressHeight = 6;
@@ -550,6 +552,14 @@ function AnimCube5(params) {
       var n = parseInt(param);
       if (n >= 9 & n <= 25)
         buttonHeight = n;
+    }
+    // get button symbols' scale, default = 1, 0.5 min., 2.5 max. according to buttonHeight
+    param = getParameter("butsymbolscale");
+    if (param != null) {
+      var n = parseFloat(param);
+      if (param < 0.5) {param = 0.5}
+      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
+      buttonSymbolScale = param;
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;
@@ -2153,50 +2163,50 @@ function AnimCube5(params) {
     y = Math.floor(y);
     switch (i) {
       case 0: // rewind
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x + ds[4], y, -1); // left
+        drawRect(g, x - ds[4]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[4]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 1: // reverse step
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[1], y, -1); // left
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 2: // reverse play
-        drawArrow(g, x + ds[1], y, -1); // left
+        drawArrow(g, x + ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 3: // stop / mirror
         if (animating)
-          drawRect(g, x - ds[4], y - ds[3], ds[7], ds[7]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[3]+ds[4])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[7]*buttonSymbolScale);
         else {
-          drawRect(g, x - ds[4], y - ds[2], ds[7], ds[5]);
-          drawRect(g, x - ds[2], y - ds[4], ds[3], ds[9]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[2]+ds[3])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[5]*buttonSymbolScale);
+          drawRect(g, x - ds[2]*buttonSymbolScale, y - (ds[4]+ds[5])/2*buttonSymbolScale, ds[3]*buttonSymbolScale, ds[9]*buttonSymbolScale);
         }
         break;
       case 4: // play
-        drawArrow(g, x - ds[2], y, 1); // right
+        drawArrow(g, x - ds[2]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 5: // step
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x, y, 1); // right
+        drawRect(g, x - (ds[4]+ds[5])/2*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[1]/2*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 6: // fast forward
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[4], y, 1); // right
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[4]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x+dpr*2 + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x-dpr + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
         break;
     }
   }
 
   function drawArrow(g, x, y, dir) {
-    var d3 = 3 * dpr;
+    var d3 = (3 * dpr)*buttonSymbolScale;
     var fillX = [];
     var fillY = [];
     fillX[0] = x;

--- a/AnimCube6.js
+++ b/AnimCube6.js
@@ -130,6 +130,8 @@ function AnimCube6(params) {
   var buttonBar; // button bar mode
   var buttonHeight;
   var drawButtons = true;
+  // including buttonSymbolScale
+  var buttonSymbolScale = 1.0;
   var pushed;
   var buttonPressed = -1;
   var progressHeight = 6;
@@ -550,6 +552,13 @@ function AnimCube6(params) {
       var n = parseInt(param);
       if (n >= 9 & n <= 25)
         buttonHeight = n;
+    }// get button symbols' scale, default = 1, 0.5 min., 2.5 max. according to buttonHeight
+    param = getParameter("butsymbolscale");
+    if (param != null) {
+      var n = parseFloat(param);
+      if (param < 0.5) {param = 0.5}
+      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
+      buttonSymbolScale = param;
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;
@@ -2194,50 +2203,50 @@ function AnimCube6(params) {
     y = Math.floor(y);
     switch (i) {
       case 0: // rewind
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x + ds[4], y, -1); // left
+        drawRect(g, x - ds[4]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[4]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 1: // reverse step
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[1], y, -1); // left
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 2: // reverse play
-        drawArrow(g, x + ds[1], y, -1); // left
+        drawArrow(g, x + ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 3: // stop / mirror
         if (animating)
-          drawRect(g, x - ds[4], y - ds[3], ds[7], ds[7]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[3]+ds[4])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[7]*buttonSymbolScale);
         else {
-          drawRect(g, x - ds[4], y - ds[2], ds[7], ds[5]);
-          drawRect(g, x - ds[2], y - ds[4], ds[3], ds[9]);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[2]+ds[3])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[5]*buttonSymbolScale);
+          drawRect(g, x - ds[2]*buttonSymbolScale, y - (ds[4]+ds[5])/2*buttonSymbolScale, ds[3]*buttonSymbolScale, ds[9]*buttonSymbolScale);
         }
         break;
       case 4: // play
-        drawArrow(g, x - ds[2], y, 1); // right
+        drawArrow(g, x - ds[2]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 5: // step
-        drawRect(g, x - ds[4], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x, y, 1); // right
+        drawRect(g, x - (ds[4]+ds[5])/2*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[1]/2*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 6: // fast forward
-        drawRect(g, x + ds[1], y - ds[3], ds[3], ds[6] + 1);
-        drawArrow(g, x - ds[4], y, 1); // right
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[4]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x+dpr*2 + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x-dpr + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
         break;
     }
   }
 
   function drawArrow(g, x, y, dir) {
-    var d3 = 3 * dpr;
+    var d3 = (3 * dpr)*buttonSymbolScale;
     var fillX = [];
     var fillY = [];
     fillX[0] = x;

--- a/AnimCube6.js
+++ b/AnimCube6.js
@@ -556,7 +556,7 @@ function AnimCube6(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5) {param = 0.5}
+      if (param < 0.5 || param > 2.5) {param = 1.0}
       if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
       buttonSymbolScale = param;
     }

--- a/AnimCube6.js
+++ b/AnimCube6.js
@@ -2234,13 +2234,13 @@ function AnimCube6(params) {
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1*buttonSymbolScale);
         break;
     }
   }

--- a/AnimCube6.js
+++ b/AnimCube6.js
@@ -556,9 +556,11 @@ function AnimCube6(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5 || param > 2.5) {param = 1.0}
-      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
-      buttonSymbolScale = param;
+      if (n > 0) {
+        if (n < 0.5 || n > 2.5) {n = 1.0}
+        if (n > 1+(buttonHeight-9)*0.09375) {n = 1+(buttonHeight-9)*0.09375}
+        buttonSymbolScale = n;
+      }
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;

--- a/AnimCube7.js
+++ b/AnimCube7.js
@@ -2325,13 +2325,13 @@ function AnimCube7(params) {
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
-        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
+        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1*buttonSymbolScale);
         break;
     }
   }

--- a/AnimCube7.js
+++ b/AnimCube7.js
@@ -553,7 +553,7 @@ function AnimCube7(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5) {param = 0.5}
+      if (param < 0.5 || param > 2.5) {param = 1.0}
       if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
       buttonSymbolScale = param;
     }

--- a/AnimCube7.js
+++ b/AnimCube7.js
@@ -553,9 +553,11 @@ function AnimCube7(params) {
     param = getParameter("butsymbolscale");
     if (param != null) {
       var n = parseFloat(param);
-      if (param < 0.5 || param > 2.5) {param = 1.0}
-      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
-      buttonSymbolScale = param;
+      if (n > 0) {
+        if (n < 0.5 || n > 2.5) {n = 1.0}
+        if (n > 1+(buttonHeight-9)*0.09375) {n = 1+(buttonHeight-9)*0.09375}
+        buttonSymbolScale = n;
+      }
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;

--- a/AnimCube7.js
+++ b/AnimCube7.js
@@ -130,6 +130,8 @@ function AnimCube7(params) {
   var buttonBar; // button bar mode
   var buttonHeight;
   var drawButtons = true;
+  // including buttonSymbolScale
+  var buttonSymbolScale = 1.0;
   var pushed;
   var buttonPressed = -1;
   var progressHeight = 6;
@@ -547,6 +549,13 @@ function AnimCube7(params) {
       var n = parseInt(param);
       if (n >= 9 & n <= 25)
         buttonHeight = n;
+    }// get button symbols' scale, default = 1, 0.5 min., 2.5 max. according to buttonHeight
+    param = getParameter("butsymbolscale");
+    if (param != null) {
+      var n = parseFloat(param);
+      if (param < 0.5) {param = 0.5}
+      if (param > 1+(buttonHeight-9)*0.09375) {param = 1+(buttonHeight-9)*0.09375}
+      buttonSymbolScale = param;
     }
     progressHeight = move.length == 0 ? 0 : 6;
     buttonBar = 1;
@@ -2280,60 +2289,60 @@ function AnimCube7(params) {
 
   var ds = []; // digits 1-9 scaled by dpr
 
-  function drawButton(g, i, x, y) { // rectangles and arrows a bit larger than the original
+  function drawButton(g, i, x, y) {
     x = Math.floor(x);
     y = Math.floor(y);
     switch (i) {
       case 0: // rewind
-        drawRect(g, x - ds[5], y - ds[5], ds[3], ds[5]*2.05);
-        drawArrow(g, x + ds[5], y, -1); // left
+        drawRect(g, x - ds[4]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[4]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 1: // reverse step
-        drawRect(g, x + ds[1], y - ds[5], ds[3], ds[5]*2.05);
-        drawArrow(g, x - ds[1], y, -1); // left
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 2: // reverse play
-        drawArrow(g, x + ds[1], y, -1); // left
+        drawArrow(g, x + ds[1]*buttonSymbolScale, y, -1*buttonSymbolScale); // left
         break;
       case 3: // stop / mirror
         if (animating)
-          drawRect(g, x - ds[5], y - ds[5], ds[5]*2.05, ds[5]*2.05);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[3]+ds[4])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[7]*buttonSymbolScale);
         else {
-          drawRect(g, x - ds[9]/2, y - ds[7]/2, ds[8], ds[5]*1.5);
-          drawRect(g, x - ds[2], y - ds[5], ds[3], ds[5]*2.05);
+          drawRect(g, x - ds[4]*buttonSymbolScale, y - (ds[2]+ds[3])/2*buttonSymbolScale, ds[7]*buttonSymbolScale, ds[5]*buttonSymbolScale);
+          drawRect(g, x - ds[2]*buttonSymbolScale, y - (ds[4]+ds[5])/2*buttonSymbolScale, ds[3]*buttonSymbolScale, ds[9]*buttonSymbolScale);
         }
         break;
       case 4: // play
-        drawArrow(g, x - ds[2], y, 1); // right
+        drawArrow(g, x - ds[2]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 5: // step
-        drawRect(g, x - ds[6], y - ds[5], ds[3], ds[5]*2.05);
-        drawArrow(g, x - ds[1]*1.5, y, 1); // right
+        drawRect(g, x - (ds[4]+ds[5])/2*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x + ds[1]/2*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 6: // fast forward
-        drawRect(g, x + ds[1], y - ds[5], ds[3], ds[5]*2.05);
-        drawArrow(g, x - ds[6], y, 1); // right
+        drawRect(g, x + ds[1]*buttonSymbolScale, y - ds[3]*buttonSymbolScale, ds[3]*buttonSymbolScale, (ds[6] + 1)*buttonSymbolScale);
+        drawArrow(g, x - ds[4]*buttonSymbolScale, y, 1*buttonSymbolScale); // right
         break;
       case 7: // prev sequence
         var c = (buttonPressed == 7) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x+dpr*2 + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, -1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x+dpr*2*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, -1*buttonSymbolScale);
         break;
       case 8: // next sequence
         var c = (buttonPressed == 8) ? darker(buttonBgColor) : buttonBgColor;
-        drawRect2(g, x-dpr*2, y+dpr, buttonHeight, y + buttonHeight, c);
-        drawArrow(g, x-dpr + buttonHeight/2 - dpr*3, y + buttonHeight/2+dph, 1);
+        drawRect2(g, x-dpr*2*buttonSymbolScale, y+dpr*buttonSymbolScale, buttonHeight*buttonSymbolScale, y + buttonHeight*buttonSymbolScale, c*buttonSymbolScale);
+        drawArrow(g, x-dpr*buttonSymbolScale + buttonHeight/2 - dpr*3*buttonSymbolScale, y + (buttonHeight/2+dph)*buttonSymbolScale, 1*buttonSymbolScale);
         break;
     }
   }
 
-  function drawArrow(g, x, y, dir) { // arrows a bit larger than the original
-    var d3 = 4.5 * dpr;
+  function drawArrow(g, x, y, dir) {
+    var d3 = (3 * dpr)*buttonSymbolScale;
     var fillX = [];
     var fillY = [];
     fillX[0] = x;
     fillX[1] = x + dir;
-    fillX[2] = x + 5 * dpr * dir;
+    fillX[2] = x + 4 * dpr * dir;
     fillX[3] = x + dir;
     fillX[4] = x;
     fillY[0] = y - d3;

--- a/sources/codes/enhancement/parameters/config_tool.html
+++ b/sources/codes/enhancement/parameters/config_tool.html
@@ -214,10 +214,13 @@
                   <option value="1" selected>1</option>
                   <option value="2">2</option>
                 </select>
-		<input type="checkbox" id="buttonbardefault" checked onchange="setdisplay('buttonbar', this.checked ? 'none' : 'inline'); replace_cube()"/>default
+		            <input type="checkbox" id="buttonbardefault" checked onchange="setdisplay('buttonbar', this.checked ? 'none' : 'inline'); replace_cube()"/>default
                 <br>
                 buttonheight: 
                 <input type="number" id="buttonheight" style="width:40px;" step="1" min="9" max="25" value="13" onchange="replace_cube()"/>
+                <br>
+                butsymbolscale:
+                <input type="number" id="butsymbolscale" style="width:40px;" step="0.1" min="0.5" max="2.5" value="1.0" onchange="replace_cube()"/>
                 <br>
               </div>
               <hr style="border-style: groove; border-width: 2px;">
@@ -555,8 +558,9 @@
         params += checked('clickprogressoff') ? '&clickprogress=0' : '';
         params += checked('snapon') ? '&snap=1' : '';
         //params += !checked('buttonbardefault') && ((getvalue('buttonbar')!='1' && (getvalue('move')!='' || getvalue('scramble')!='0')) || (getvalue('buttonbar')=='1' && getvalue('move')=='' && getvalue('scramble')=='0')) ? '&buttonbar='+getvalue('buttonbar') : '';
-	params += !checked('buttonbardefault') ? '&buttonbar='+getvalue('buttonbar') : '';
+	      params += !checked('buttonbardefault') ? '&buttonbar='+getvalue('buttonbar') : '';
         params += getvalue('buttonheight')!='13' ? '&buttonheight='+getvalue('buttonheight') : '';
+        params += getvalue('butsymbolscale')!='1' ? '&butsymbolscale='+getvalue('butsymbolscale') : '';
         params += checked('repeatoff') ? '&repeat=0' : '';
         params += checked('editoff') ? '&edit=0' : '';
         params += getvalue('speed')!='10' ? '&speed='+getvalue('speed') : '';


### PR DESCRIPTION
Introduce a buttonSymbolScale (default 1.0) and a new getParameter("butsymbolscale") option to AnimCube2..AnimCube7. The value is clamped (min 0.5, max derived from buttonHeight) and is applied to button rectangles, arrows and arrow sizing (drawArrow d3) so button symbols scale consistently with buttonHeight. Updates adjust positions/sizes accordingly across the six AnimCube files to support the new scaling parameter. Small misalignements (not noticeable at scale 1) present in pause/stop and step were also fixed.