### PR TITLE
Fix info text issue due to wca option.

### DIFF
--- a/AnimCube3.js
+++ b/AnimCube3.js
@@ -861,7 +861,13 @@ function AnimCube3(params) {
   function wca_to_sign(s) {
     for (var i=0; i < 6; i++) {
       var r = new RegExp(faces[i] + 'w', "g");
-      s = s.replace(r, faces[i].toLowerCase());
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i].toLowerCase());
+      });
     }
     return s;
   }

--- a/AnimCube4.js
+++ b/AnimCube4.js
@@ -887,7 +887,13 @@ function AnimCube4(params) {
     for (var i=0; i < 6; i++) {
       var f = (t==0) ? faces[i] : faces[i].toLowerCase();
       var r = new RegExp(a + f, "g");
-      s = s.replace(r, faces[i] + b);
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i] + b);
+      });
     }
     return s;
   }

--- a/AnimCube4.js
+++ b/AnimCube4.js
@@ -867,9 +867,15 @@ function AnimCube4(params) {
   }
 
   function convertNotation4(s) {
-    s = s.replace(/^e| e/g, " Dw").
-          replace(/^s| s/g, " Fw").
-          replace(/^m| m/g, " Lw");
+    s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+      // If it starts with {, it is an info box then leave as it is
+      if (trecho.startsWith("{")) return trecho;
+      // otherwise, apply the replacements
+      return trecho
+      .replace(/^e| e/g, " Dw")
+      .replace(/^s| s/g, " Fw")
+      .replace(/^m| m/g, " Lw");
+    });
     s = replaceMoves(s, 2, 'm', 0);
     s = replaceMoves(s, 2, 't', 1);
     return s;
@@ -889,7 +895,13 @@ function AnimCube4(params) {
   function wca_to_sign(s) {
     for (var i=0; i < 6; i++) {
       var r = new RegExp(faces[i] + 'w', "g");
-      s = s.replace(r, faces[i].toLowerCase());
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i].toLowerCase());
+      });
     }
     return s;
   }

--- a/AnimCube5.js
+++ b/AnimCube5.js
@@ -877,7 +877,13 @@ function AnimCube5(params) {
   function wca_to_sign(s) {
     for (var i=0; i < 6; i++) {
       var r = new RegExp(faces[i] + 'w', "g");
-      s = s.replace(r, faces[i].toLowerCase());
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i].toLowerCase());
+      });
     }
     return s;
   }

--- a/AnimCube5.js
+++ b/AnimCube5.js
@@ -869,7 +869,13 @@ function AnimCube5(params) {
     for (var i=0; i < 6; i++) {
       var f = (t==0) ? faces[i] : faces[i].toLowerCase();
       var r = new RegExp(a + f, "g");
-      s = s.replace(r, faces[i] + b);
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i] + b);
+      });
     }
     return s;
   }

--- a/AnimCube6.js
+++ b/AnimCube6.js
@@ -874,7 +874,13 @@ function AnimCube6(params) {
     for (var i=0; i < 6; i++) {
       var f = (t==0) ? faces[i] : faces[i].toLowerCase();
       var r = new RegExp(a + f, "g");
-      s = s.replace(r, faces[i] + b);
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i] + b);
+      });
     }
     return s;
   }

--- a/AnimCube6.js
+++ b/AnimCube6.js
@@ -882,7 +882,13 @@ function AnimCube6(params) {
   function wca_to_sign(s) {
     for (var i=0; i < 6; i++) {
       var r = new RegExp(faces[i] + 'w', "g");
-      s = s.replace(r, faces[i].toLowerCase());
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i].toLowerCase());
+      });
     }
     return s;
   }

--- a/AnimCube7.js
+++ b/AnimCube7.js
@@ -875,7 +875,13 @@ function AnimCube7(params) {
   function wca_to_sign(s) {
     for (var i=0; i < 6; i++) {
       var r = new RegExp(faces[i] + 'w', "g");
-      s = s.replace(r, faces[i].toLowerCase());
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i].toLowerCase());
+      });
     }
     return s;
   }

--- a/AnimCube7.js
+++ b/AnimCube7.js
@@ -867,7 +867,13 @@ function AnimCube7(params) {
     for (var i=0; i < 6; i++) {
       var f = (t==0) ? faces[i] : faces[i].toLowerCase();
       var r = new RegExp(a + f, "g");
-      s = s.replace(r, faces[i] + b);
+      s = s.replace(/\{[^}]*\}|[^{}]+/g, (trecho) => {
+        // If it starts with {, it is an info box then leave as it is
+        if (trecho.startsWith("{")) return trecho;
+        // otherwise, apply the replacements
+        return trecho
+        .replace(r, faces[i] + b);
+      });
     }
     return s;
   }


### PR DESCRIPTION
Fix info text issue due to wca option. The functions wca_to_sign (animcube3 to 7) and convertNotation4 (animcube4) now filter out info text in between braces {} before doing the conversion. The fix is not unbreakable; for example, you cannot nest braces, but this would break the script even before the fix.

To see the original issue try: AnimCubeN("move={Cube made easy and simple: Dw Fw} Dw Fw&wca=1") where N=3, 4, 5, 6, 7